### PR TITLE
Move 'move' method from Organism to Animal class & Add move logic in Map class

### DIFF
--- a/src/main/java/ecosim/attrs/Locatable.java
+++ b/src/main/java/ecosim/attrs/Locatable.java
@@ -1,0 +1,28 @@
+package ecosim.attrs;
+
+
+import ecosim.map.Coords;
+
+
+/**
+ * An object with 2D coordinates.
+ * 
+ * @author darragh0
+ */
+public abstract class Locatable {
+
+    protected final Coords coords;
+
+    public Locatable(final int x, final int y) {
+        this.coords = new Coords(x, y);
+    }
+
+    public final int getX() {
+        return this.coords.getX();
+    }
+
+    public final int getY() {
+        return this.coords.getY();
+    }
+
+}

--- a/src/main/java/ecosim/attrs/Movable.java
+++ b/src/main/java/ecosim/attrs/Movable.java
@@ -1,33 +1,13 @@
 package ecosim.attrs;
 
 
-import ecosim.map.Coords;
-
-
 /**
- * An object with adjustable 2D coordinates.
+ * An object with *adjustable* 2D coordinates.
  * 
  * @author darragh0
  */
-public abstract class Movable {
+public interface Movable {
 
-    protected final Coords coords;
-
-    public Movable(final int x, final int y) {
-        this.coords = new Coords(x, y);
-    }
-
-    public void setCoords(final int x, final int y) {
-        this.coords.setX(x);
-        this.coords.setY(y);
-    }
-
-    public int getX() {
-        return this.coords.getX();
-    }
-
-    public int getY() {
-        return this.coords.getY();
-    }
+    public void setCoords(final int x, final int y);
 
 }

--- a/src/main/java/ecosim/map/Map.java
+++ b/src/main/java/ecosim/map/Map.java
@@ -69,8 +69,7 @@ public class Map {
                 continue;
 
             Organism otherOrg = cell.get();
-            if (otherOrg.isAnimal()) {
-                Animal otherAn = (Animal) otherOrg;
+            if (otherOrg instanceof Animal otherAn) {
                 if (an.getSize().getNutritionalValue() < otherAn.getSize().getNutritionalValue())
                     continue;
             }

--- a/src/main/java/ecosim/organism/Organism.java
+++ b/src/main/java/ecosim/organism/Organism.java
@@ -1,7 +1,7 @@
 package ecosim.organism;
 
 
-import ecosim.attrs.Movable;
+import ecosim.attrs.Locatable;
 
 
 /**
@@ -9,7 +9,7 @@ import ecosim.attrs.Movable;
  * 
  * @author darragh0
  */
-public abstract class Organism extends Movable {
+public abstract class Organism extends Locatable {
 
     protected final char symbol;
     protected final int nutritionalValue;

--- a/src/main/java/ecosim/organism/Organism.java
+++ b/src/main/java/ecosim/organism/Organism.java
@@ -28,10 +28,6 @@ public abstract class Organism extends Locatable {
 
     public abstract void update();
 
-    public boolean isAnimal() {
-        return false;
-    }
-
     public String getName() {
         return name;
     }

--- a/src/main/java/ecosim/organism/Organism.java
+++ b/src/main/java/ecosim/organism/Organism.java
@@ -2,8 +2,6 @@ package ecosim.organism;
 
 
 import ecosim.attrs.Movable;
-import ecosim.enm.Direction;
-import ecosim.map.Map;
 
 
 /**
@@ -18,7 +16,7 @@ public abstract class Organism extends Movable {
     protected final float maxHealth;
     protected float health;
     protected String name;
-  
+
     public Organism(final float maxHealth, final int x, final int y, final int nutritionalValue) {
         super(x, y);
         this.symbol = 'E'; // can change later
@@ -26,18 +24,18 @@ public abstract class Organism extends Movable {
         this.maxHealth = maxHealth;
         this.health = maxHealth;
         this.name = "organism";
-
-    }
-
-    public void move(final Direction dir) {
-        Map.getInstance().moveEntity(this, dir);
     }
 
     public abstract void update();
 
+    public boolean isAnimal() {
+        return false;
+    }
+
     public String getName() {
         return name;
     }
+
     public char getSymbol() {
         return this.symbol;
     }

--- a/src/main/java/ecosim/organism/animal/Animal.java
+++ b/src/main/java/ecosim/organism/animal/Animal.java
@@ -1,6 +1,7 @@
 package ecosim.organism.animal;
 
 
+import ecosim.attrs.Movable;
 import ecosim.enm.ActivityType;
 import ecosim.enm.Diet;
 import ecosim.enm.Size;
@@ -10,7 +11,7 @@ import ecosim.organism.animal.conscious_state.Conscious;
 import ecosim.organism.animal.conscious_state.ConsciousState;
 
 
-public abstract class Animal extends Organism {
+public abstract class Animal extends Organism implements Movable {
 
     protected Size size;
     protected Diet diet;
@@ -81,6 +82,10 @@ public abstract class Animal extends Organism {
         Map.getInstance().move(this);
     }
 
-
+    @Override
+    public void setCoords(int x, int y) {
+        this.coords.setX(x);
+        this.coords.setY(y);
+    }
 
 }

--- a/src/main/java/ecosim/organism/animal/Animal.java
+++ b/src/main/java/ecosim/organism/animal/Animal.java
@@ -4,6 +4,7 @@ package ecosim.organism.animal;
 import ecosim.enm.ActivityType;
 import ecosim.enm.Diet;
 import ecosim.enm.Size;
+import ecosim.map.Map;
 import ecosim.organism.Organism;
 import ecosim.organism.animal.conscious_state.Conscious;
 import ecosim.organism.animal.conscious_state.ConsciousState;
@@ -55,6 +56,11 @@ public abstract class Animal extends Organism {
     @Override
     public void update() {}
 
+    @Override
+    public boolean isAnimal() {
+        return true;
+    }
+
     public void move() {
         this.awakeState.move();
     }
@@ -70,5 +76,11 @@ public abstract class Animal extends Organism {
     public boolean isEdible(Organism organism) {
         return false;
     }
+
+    public void iWasGonnaCallThisFunctionMoveButICANTBecauseSomeoneElseAlreadyTookTheNameMoveSoIAmLeftToComeUpWithAnotherNameForThisMethodWhichHasUnfortunatelyBecomeVeryLongAsAResultOfTheFactThatSomebodyHasReservedTheMoveNameSoNowImSadAndHeresALongMethodName() {
+        Map.getInstance().move(this);
+    }
+
+
 
 }

--- a/src/main/java/ecosim/organism/animal/Animal.java
+++ b/src/main/java/ecosim/organism/animal/Animal.java
@@ -57,11 +57,6 @@ public abstract class Animal extends Organism implements Movable {
     @Override
     public void update() {}
 
-    @Override
-    public boolean isAnimal() {
-        return true;
-    }
-
     public void move() {
         this.awakeState.move();
     }


### PR DESCRIPTION
- Move 'move' method from `Organism` to `Animal` (since plants can't move on the map).
- Add move logic for animals on the map.
- Make `Organism` extend from `Locatable` to rather than `Movable` and make **only animals** movable
