### PR TITLE
Remove `value` attr & `getValue` method from enums

### DIFF
--- a/src/main/java/ecosim/Environment.java
+++ b/src/main/java/ecosim/Environment.java
@@ -4,6 +4,7 @@ package ecosim;
 import java.util.List;
 
 import ecosim.attrs.Observer;
+import ecosim.enm.Biome;
 import ecosim.enm.Season;
 import ecosim.enm.TimeOfDay;
 import ecosim.enm.Weather;
@@ -14,62 +15,63 @@ import ecosim.man.WeatherMan;
 
 
 public class Environment {
-    private WeatherMan weatherManager;
-    private SeasonMan seasonManager;
-    private TimeOfDayMan timeOfDayManager;
-    private BiomeMan biome;
+    private WeatherMan weatherMan;
+    private SeasonMan seasonMan;
+    private TimeOfDayMan timeOfDayMan;
+    private BiomeMan biomeMan;
 
-    public void setBiome(String biomeName) {
-        this.biome = new BiomeMan(biomeName);
-        this.biome.setupBiome();
+    public void setBiome(final Biome biome) {
+        this.biomeMan = new BiomeMan(biome);
+        this.biomeMan.setupBiome();
     }
 
     public void updateSeason() {
-        this.seasonManager.getNextSeason();
+        this.seasonMan.getNextSeason();
         // load probabilities for new season
-        weatherManager.loadWeatherProbabilities(this.biome.getBiomeName(),
-            this.seasonManager.getCurrentState().toString());
+        weatherMan.loadWeatherProbabilities(
+            this.biomeMan.getBiome(),
+            this.seasonMan.getCurrentState().toString());
     }
 
     public void updateDay() {
-        this.timeOfDayManager.switchTimeOfDay();
+        this.timeOfDayMan.switchTimeOfDay();
     }
 
     public void updateWeather() {
-        this.weatherManager.updateRandomWeather();
+        this.weatherMan.updateRandomWeather();
 
     }
 
     public Weather getWeather() {
-        return this.weatherManager.getCurrentState();
+        return this.weatherMan.getCurrentState();
     }
 
     public Season getSeason() {
-        return this.seasonManager.getCurrentState();
+        return this.seasonMan.getCurrentState();
     }
 
     public TimeOfDay getTimeOfDay() {
-        return this.timeOfDayManager.getCurrentState();
+        return this.timeOfDayMan.getCurrentState();
     }
 
     public List<String> getBiomeNativeAnimals() {
-        return this.biome.getNativeAnimals();
+        return this.biomeMan.getNativeAnimals();
     }
 
     public List<String> getBiomeNativePlants() {
-        return this.biome.getNativePlants();
+        return this.biomeMan.getNativePlants();
     }
 
-    public void registerTimeOfDayObservers(Observer observer){
-        this.timeOfDayManager.attach(observer);
+    public void registerTimeOfDayObservers(Observer observer) {
+        this.timeOfDayMan.attach(observer);
     }
 
-    public void registerSeasonObservers(Observer observer){
-        this.seasonManager.attach(observer);
+    public void registerSeasonObservers(Observer observer) {
+        this.seasonMan.attach(observer);
     }
 
-    public void registerWeatherObservers(Observer observer){
-        this.weatherManager.attach(observer);
+    public void registerWeatherObservers(Observer observer) {
+        this.weatherMan.attach(observer);
     }
 
 }

--- a/src/main/java/ecosim/Environment.java
+++ b/src/main/java/ecosim/Environment.java
@@ -30,7 +30,7 @@ public class Environment {
         // load probabilities for new season
         weatherMan.loadWeatherProbabilities(
             this.biomeMan.getBiome(),
-            this.seasonMan.getCurrentState().toString());
+            this.seasonMan.getCurrentState());
     }
 
     public void updateDay() {
@@ -39,7 +39,6 @@ public class Environment {
 
     public void updateWeather() {
         this.weatherMan.updateRandomWeather();
-
     }
 
     public Weather getWeather() {

--- a/src/main/java/ecosim/controller/EcosystemController.java
+++ b/src/main/java/ecosim/controller/EcosystemController.java
@@ -37,21 +37,21 @@ public class EcosystemController {
     }
 
     public void setup() {
-        Environment env = this.man.getEnvironment();
-        Biome biome = this.view.promptBiomeSelection();
+        final Environment env = this.man.getEnvironment();
+        final Biome biome = this.view.promptBiomeSelection();
 
-        env.setBiome(biome.getName());
+        env.setBiome(biome);
 
         final List<String> animals = this.view.promptAnimalSelection(env.getBiomeNativeAnimals(), 3);
         final List<String> plants = this.view.promptPlantSelection(env.getBiomeNativePlants(), 3);
 
         // load ecosystem with animals and plants once factory is implemented
         for (String animal : animals) {
-            this.man.createAnimal(animal, biome.getName());
+            this.man.createAnimal(animal, biome.name());
         }
 
         for (String plant : plants) {
-            this.man.createPlant(plant, biome.getName());
+            this.man.createPlant(plant, biome.name());
         }
 
         this.man.populateMap();

--- a/src/main/java/ecosim/enm/ActivityState.java
+++ b/src/main/java/ecosim/enm/ActivityState.java
@@ -1,5 +1,6 @@
 package ecosim.enm;
 
+
 /**
  * Enum representing the various activity states
  * an organism can be in, such as sleeping or hibernating.
@@ -7,5 +8,7 @@ package ecosim.enm;
  * @author jjola00
  */
 public enum ActivityState {
-    SLEEPING, HIBERNATING, AWAKE
+    SLEEPING,
+    HIBERNATING,
+    AWAKE
 }

--- a/src/main/java/ecosim/enm/Biome.java
+++ b/src/main/java/ecosim/enm/Biome.java
@@ -1,16 +1,7 @@
 package ecosim.enm;
 
+
 public enum Biome {
-    DESERT("Desert"),
-    GRASSLAND("Grassland");
-
-    private final String name;
-
-    Biome(String name) {
-        this.name = name;
-    }
-
-    public String getName(){
-        return this.name;
-    }
+    DESERT,
+    GRASSLAND;
 }

--- a/src/main/java/ecosim/enm/Event.java
+++ b/src/main/java/ecosim/enm/Event.java
@@ -1,5 +1,5 @@
 package ecosim.enm;
 
+
 public interface Event {
-    String getValue();
 }

--- a/src/main/java/ecosim/enm/Season.java
+++ b/src/main/java/ecosim/enm/Season.java
@@ -1,19 +1,9 @@
 package ecosim.enm;
 
+
 public enum Season implements Event {
-    SPRING("Spring"),
-    SUMMER("Summer"),
-    AUTUMN("Autumn"),
-    WINTER("Winter");
-
-    private final String value;
-
-    Season(String value) {
-        this.value = value;
-    }
-
-    @Override
-    public String getValue() {
-        return value;
-    }
+    SPRING,
+    SUMMER,
+    AUTUMN,
+    WINTER;
 }

--- a/src/main/java/ecosim/enm/TimeOfDay.java
+++ b/src/main/java/ecosim/enm/TimeOfDay.java
@@ -1,17 +1,7 @@
 package ecosim.enm;
 
+
 public enum TimeOfDay implements Event {
-    DAY("Day"),
-    NIGHT("Night");
-
-    private final String value;
-
-    TimeOfDay(String value) {
-        this.value = value;
-    }
-
-    @Override
-    public String getValue() {
-        return value;
-    }
+    DAY,
+    NIGHT;
 }

--- a/src/main/java/ecosim/enm/Weather.java
+++ b/src/main/java/ecosim/enm/Weather.java
@@ -1,20 +1,10 @@
 package ecosim.enm;
 
+
 public enum Weather implements Event {
-    RAINY("Rainy"),
-    SUNNY("Sunny"),
-    DRY("Dry"),
-    CLOUDY("Cloudy"),
-    SNOWY("Snowy");
-
-    private final String value;
-
-    Weather(String value) {
-        this.value = value;
-    }
-
-    @Override
-    public String getValue() {
-        return value;
-    }
+    RAINY,
+    SUNNY,
+    DRY,
+    CLOUDY,
+    SNOWY;
 }

--- a/src/main/java/ecosim/man/BiomeMan.java
+++ b/src/main/java/ecosim/man/BiomeMan.java
@@ -19,20 +19,16 @@ public class BiomeMan {
     private final List<String> nativeAnimals;
     private final List<String> nativePlants;
 
-    public BiomeMan(String biomeName) {
-        this.biome = Biome.valueOf(biomeName.toUpperCase());
+    public BiomeMan(final Biome biome) {
+        this.biome = biome;
         this.nativeAnimals = new ArrayList<>();
         this.nativePlants = new ArrayList<>();
-        LoggerMan.log(Level.INFO, "Biome created: " + this.biome.getName());
-    }
-
-    public String getBiomeName() {
-        return this.biome.getName().toUpperCase();
+        LoggerMan.log(Level.INFO, "Biome created: " + this.biome.name());
     }
 
     public void setupBiome() {
-        LoggerMan.log(Level.INFO, "Setting up biome: {0}", this.getBiomeName());
-        final String biomeName = this.getBiomeName();
+        final String biomeName = this.biome.name();
+        LoggerMan.log(Level.INFO, "Setting up biome: {0}", biomeName);
         final Optional<JSONObject> jsonFile = FileIO.readJSONFile("src/main/resources/json/biome_natives.json");
 
         if (jsonFile.isEmpty()) {
@@ -57,7 +53,6 @@ public class BiomeMan {
                 return;
             }
 
-
             final JSONArray jsonArr = biomeData.getJSONArray(name);
             for (int i = 0; i < jsonArr.length(); i++) {
                 lst.add(jsonArr.getString(i));
@@ -67,6 +62,10 @@ public class BiomeMan {
         });
 
         LoggerMan.log(Level.INFO, "Biome setup complete: {0}", biomeName);
+    }
+
+    public Biome getBiome() {
+        return this.biome;
     }
 
     public List<String> getNativeAnimals() {

--- a/src/main/java/ecosim/man/WeatherMan.java
+++ b/src/main/java/ecosim/man/WeatherMan.java
@@ -12,6 +12,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import ecosim.attrs.Observable;
+import ecosim.enm.Biome;
 import ecosim.enm.Weather;
 
 
@@ -30,9 +31,9 @@ public class WeatherMan extends Observable {
         return this.currentWeather;
     }
 
-    public void loadWeatherProbabilities(String biome, String season) {
-        String upperBiome = biome.toUpperCase();
-        String upperSeason = season.toUpperCase();
+    public void loadWeatherProbabilities(final Biome biome, String season) {
+        String biomeName = biome.name();
+        String seasonName = season.toUpperCase();
         Map<Weather, Double> tempProbabilities = new HashMap<>();
 
         try {
@@ -40,20 +41,20 @@ public class WeatherMan extends Observable {
                 new String(Files.readAllBytes(Paths.get("src/main/resources/json/weather_probabilities.json")));
             JSONObject json = new JSONObject(content);
 
-            if (json.has(upperBiome)) {
-                JSONObject biomeData = json.getJSONObject(upperBiome);
-                if (biomeData.has(upperSeason)) {
-                    JSONObject seasonData = biomeData.getJSONObject(upperSeason);
+            if (json.has(biomeName)) {
+                JSONObject biomeData = json.getJSONObject(biomeName);
+                if (biomeData.has(seasonName)) {
+                    JSONObject seasonData = biomeData.getJSONObject(seasonName);
                     for (String key : seasonData.keySet()) {
                         Weather weather = Weather.valueOf(key.toUpperCase());
                         double probability = seasonData.getDouble(key);
                         tempProbabilities.put(weather, probability);
                     }
                 } else {
-                    LoggerMan.log(Level.WARNING, "Season not found for biome: {0}", upperSeason);
+                    LoggerMan.log(Level.WARNING, "Season not found for biome: {0}", seasonName);
                 }
             } else {
-                LoggerMan.log(Level.WARNING, "Biome not found: {0}", upperBiome);
+                LoggerMan.log(Level.WARNING, "Biome not found: {0}", biomeName);
             }
         } catch (IOException | JSONException | IllegalArgumentException e) {
             LoggerMan.log(Level.SEVERE, "Error loading weather probabilities: {0}", e.getMessage());

--- a/src/main/java/ecosim/man/WeatherMan.java
+++ b/src/main/java/ecosim/man/WeatherMan.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 
 import ecosim.attrs.Observable;
 import ecosim.enm.Biome;
+import ecosim.enm.Season;
 import ecosim.enm.Weather;
 
 
@@ -31,9 +32,9 @@ public class WeatherMan extends Observable {
         return this.currentWeather;
     }
 
-    public void loadWeatherProbabilities(final Biome biome, String season) {
+    public void loadWeatherProbabilities(final Biome biome, final Season season) {
         String biomeName = biome.name();
-        String seasonName = season.toUpperCase();
+        String seasonName = season.name();
         Map<Weather, Double> tempProbabilities = new HashMap<>();
 
         try {


### PR DESCRIPTION
- Remove redundant `value` attr and `getValue` method in `Biome` Enum.
    - Change `Environment.setBiome` String param to Enum.
    - Change `BiomeMan` constructor String param to Enum & remove `getBiomeName()` method.
    - Change `WeatherMan.loadWeatherProbabilities` String param to Enum.
    - Fix `ActivityState` formatting.

- Remove redundant `value` attr and `getValue` method in `Season`, `TimeOfDay`, and `Weather` Enums.
    - Remove `getValue` method from `Event` interface.
    - Change `WeatherMan.loadWeatherProbabilities` String param to Enum.
